### PR TITLE
make startCapture method public

### DIFF
--- a/ZCSAvatarCaptureController.h
+++ b/ZCSAvatarCaptureController.h
@@ -20,4 +20,6 @@
 @property (weak) id<ZCSAvatarCaptureControllerDelegate> delegate;
 @property (strong, nonatomic) UIImage *image;
 
+- (void)startCapture;
+
 @end

--- a/ZCSAvatarCaptureController.m
+++ b/ZCSAvatarCaptureController.m
@@ -27,7 +27,6 @@
 @property (nonatomic, strong) UIView *imageSelectedView;
 @property (nonatomic, strong) UIImage *selectedImage;
 
-- (void)startCapture;
 - (void)endCapture;
 
 @end


### PR DESCRIPTION
so we could start editing programmatically (currently
performSelector(startCapture) is getting the job done)
